### PR TITLE
this jupyter notebook was not loading due to missing double quotes in…

### DIFF
--- a/Hands-on Labs/Run a Batch Inferencing Pipeline and Obtain Outputs.ipynb
+++ b/Hands-on Labs/Run a Batch Inferencing Pipeline and Obtain Outputs.ipynb
@@ -414,7 +414,7 @@
       "source": [
         "## Retrieve the saved outputs",
         "\n",
-        "*Do not proceed until the pipeline run shows complete in the separate Azure ML Studio browser tab.*
+        "*Do not proceed until the pipeline run shows complete in the separate Azure ML Studio browser tab.*"
       ],
       "metadata": {}
     },


### PR DESCRIPTION
PR to fix the commit c89fbeb

Jupyter notebook was not loading due to json error in the file, due to which I was not able to load  in Azure machine learning studio, fixed the issue adding the double quotes to the markdown cell sentence.

File impacted
Run a Batch Inferencing Pipeline and Obtain Outputs.ipynb
